### PR TITLE
cli_attrs.require_options/allow_positional_args both default to None

### DIFF
--- a/bourbaki/application/cli/decorators.py
+++ b/bourbaki/application/cli/decorators.py
@@ -209,11 +209,11 @@ class cli_attrs:
     """retrieve properties set on functions by cli_spec methods"""
 
     @staticmethod
-    def allow_positional_args(f, default=True):
+    def allow_positional_args(f, default=None):
         return getattr(f, "__allow_positional_args__", default)
 
     @staticmethod
-    def require_options(f, default=False):
+    def require_options(f, default=None):
         if hasattr(f, "__allow_positional_args__"):
             return not cli_attrs.allow_positional_args(f)
         return default

--- a/bourbaki/application/cli/signatures.py
+++ b/bourbaki/application/cli/signatures.py
@@ -98,7 +98,10 @@ class CLISignatureSpec(NamedTuple):
     def overriding(self, *others: "CLISignatureSpec") -> "CLISignatureSpec":
         namespaces = [n.nonnull_attrs for n in chain((self,), others)]
         metavars = ChainMap(*filter(None, (n.get("metavars") for n in namespaces)))
-        return CLISignatureSpec(**ChainMap({"metavars": metavars}, *namespaces))
+        result = CLISignatureSpec(**ChainMap({"metavars": metavars}, *namespaces))
+        if result.require_options is None:
+            result.require_options = False
+        return result
 
     def configure(
         self, sig: Signature, warn_missing: Optional[Callable[[str], None]] = None


### PR DESCRIPTION
cli_attrs.require_options/allow_positional_args both default to None to play nicely with the CLISignatureSpec.overriding machinery