### PR TITLE
Subcommand help

### DIFF
--- a/bourbaki/application/cli/actions.py
+++ b/bourbaki/application/cli/actions.py
@@ -138,4 +138,5 @@ class SetExecuteFlagAction(Action):
 
     def __call__(self, parser, namespace, values, option_string=None):
         from bourbaki.application.cli import main
+
         main.EXECUTE = True

--- a/bourbaki/application/cli/decorators.py
+++ b/bourbaki/application/cli/decorators.py
@@ -25,14 +25,16 @@ class cli_spec:
         """mark a function as not to be processed as a command for a CLI (usually a method in a class def)"""
         f.__noncommand__ = True
         return f
-    
+
     @staticmethod
     def command_name(name):
         """specify a command name string to override the function name. If a prefix is also specified, this will be 
         the last token in the command path for the function after the prefix"""
+
         def dec(f):
             f.__command_name__ = name
             return f
+
         return dec
 
     @staticmethod
@@ -194,6 +196,7 @@ class cli_spec:
         def dec(f):
             f.__exit_codes__ = codes
             return f
+
         return dec
 
     @staticmethod

--- a/bourbaki/application/cli/main.py
+++ b/bourbaki/application/cli/main.py
@@ -1,5 +1,15 @@
 # coding:utf-8
-from typing import Iterator, Union, Tuple, Mapping, List, Set, Callable, Type, Optional as Opt
+from typing import (
+    Iterator,
+    Union,
+    Tuple,
+    Mapping,
+    List,
+    Set,
+    Callable,
+    Type,
+    Optional as Opt,
+)
 import copy
 import os
 import sys
@@ -78,7 +88,7 @@ from .helpers import (
 from .decorators import cli_attrs, NO_OUTPUT_HANDLER
 from .signatures import CLISignatureSpec, FinalCLISignatureSpec
 
-__all__ = ['CommandLineInterface', 'ArgSource', 'DEFAULT_LOOKUP_ORDER']
+__all__ = ["CommandLineInterface", "ArgSource", "DEFAULT_LOOKUP_ORDER"]
 
 # only need to parse docs once for any function
 parse_docstring = lru_cache(None)(parse_docstring)
@@ -169,12 +179,14 @@ class WideHelpFormatter(RawDescriptionHelpFormatter):
 
 
 class CLIErrorHandlingContext:
-    def __init__(self, exit_codes: Mapping[Type[Exception], int] = None, verbose: bool = False):
+    def __init__(
+        self, exit_codes: Mapping[Type[Exception], int] = None, verbose: bool = False
+    ):
         if exit_codes is None:
             exit_codes = {Exception: 1}
         self.verbose = verbose
         self.exit_codes = exit_codes
-        self.exit_code = GenericTypeLevelSingleDispatch('exit_code')
+        self.exit_code = GenericTypeLevelSingleDispatch("exit_code")
         self.exit_code.register_from_mapping(exit_codes, as_const=True)
 
     def __enter__(self):
@@ -257,9 +269,11 @@ class PicklableArgumentParser(ArgumentParser):
         return subparsers
 
     def get_nested_subparser(
-            self, *cmd_path: str,
-            prefix: Tuple[str, ...] = (),
-            subcommand_help: Opt[Mapping[Tuple[str, ...], str]] = None):
+        self,
+        *cmd_path: str,
+        prefix: Tuple[str, ...] = (),
+        subcommand_help: Opt[Mapping[Tuple[str, ...], str]] = None,
+    ):
         if not cmd_path:
             return self
 
@@ -276,9 +290,7 @@ class PicklableArgumentParser(ArgumentParser):
                 subparser = subparsers.add_parser(cmdname)
 
         return subparser.get_nested_subparser(
-            *cmd_path[1:],
-            prefix=prefix + cmd_path[:1],
-            subcommand_help=subcommand_help,
+            *cmd_path[1:], prefix=prefix + cmd_path[:1], subcommand_help=subcommand_help
         )
 
 
@@ -710,8 +722,9 @@ class CommandLineInterface(PicklableArgumentParser, Logged):
         if subcommand_help is not None:
             if not isinstance(subcommand_help, Mapping):
                 raise TypeError(
-                    "subcommand_help must be a mapping from command path to help string; got {}"
-                    .format(type(subcommand_help))
+                    "subcommand_help must be a mapping from command path to help string; got {}".format(
+                        type(subcommand_help)
+                    )
                 )
             self.subcommand_help = {
                 tuple(k.strip().split() if isinstance(k, str) else k): v
@@ -907,12 +920,16 @@ class CommandLineInterface(PicklableArgumentParser, Logged):
     ##############
 
     def get_nested_subparser(
-            self, *cmd_path: str,
-            prefix: Tuple[str, ...] = (),
-            subcommand_help: Opt[Mapping[Tuple[str, ...], str]] = None):
+        self,
+        *cmd_path: str,
+        prefix: Tuple[str, ...] = (),
+        subcommand_help: Opt[Mapping[Tuple[str, ...], str]] = None,
+    ):
         if subcommand_help is None:
             subcommand_help = self.subcommand_help
-        return super().get_nested_subparser(*cmd_path, prefix=prefix, subcommand_help=subcommand_help)
+        return super().get_nested_subparser(
+            *cmd_path, prefix=prefix, subcommand_help=subcommand_help
+        )
 
     def all_subcommands(
         self,
@@ -996,7 +1013,9 @@ class CommandLineInterface(PicklableArgumentParser, Logged):
         else:
             exit_codes = ChainMap(cmdfunc.exit_codes, self.exit_codes)
 
-        with CLIErrorHandlingContext(exit_codes, verbose=verbosity >= TRACEBACK_VERBOSITY):
+        with CLIErrorHandlingContext(
+            exit_codes, verbose=verbosity >= TRACEBACK_VERBOSITY
+        ):
             app_logger = self.get_app_logger(ns)
             app_logger.debug("command is %r", cmdname)
             config = self.parse_config(ns, app_logger) if self.use_config else None
@@ -1375,7 +1394,7 @@ class CommandLineInterface(PicklableArgumentParser, Logged):
                         )
                     )
                 continue
-            
+
             cmd_name = cli_attrs.command_name(f, default=name)
             self.subcommand(name=cmd_name, from_method=True, tvar_map=tvar_map)(f)
 
@@ -2237,7 +2256,9 @@ class SubCommandFunc(Logged):
                     else:
                         # only repr the non-null type options when there is a default, to simplify
                         NoneType = type(None)
-                        types = tuple(t for t in get_generic_args(tio.type_) if t is not NoneType)
+                        types = tuple(
+                            t for t in get_generic_args(tio.type_) if t is not NoneType
+                        )
                         if len(types) == 1:
                             val = TypedIO(types[0]).config_repr
                         else:

--- a/bourbaki/application/cli/main.py
+++ b/bourbaki/application/cli/main.py
@@ -225,12 +225,17 @@ class _SubparserPathAction(_SubParsersAction):
 class PicklableArgumentParser(ArgumentParser):
     cmd_prefix = ()
 
+    # this shim makes argument parsers picklable (argparse argument parsers are not)
     def __init__(self, *args, **kwargs):
         kwargs["formatter_class"] = WideHelpFormatter
         super().__init__(*args, **kwargs)
         # ArgumentParser won't pickle, we have to override its registry here
         self.register("type", None, identity)
         self.register("action", "parsers", _SubparserPathAction)
+
+    ##############
+    # subparsers #
+    ##############
 
     def add_subparsers(self, *args, **kwargs) -> _SubparserPathAction:
         subparsers = super().add_subparsers(*args, **kwargs)
@@ -251,7 +256,10 @@ class PicklableArgumentParser(ArgumentParser):
         self._subparsers_action = subparsers
         return subparsers
 
-    def get_nested_subparser(self, *cmd_path: str):
+    def get_nested_subparser(
+            self, *cmd_path: str,
+            prefix: Tuple[str, ...] = (),
+            subcommand_help: Opt[Mapping[Tuple[str, ...], str]] = None):
         if not cmd_path:
             return self
 
@@ -260,9 +268,18 @@ class PicklableArgumentParser(ArgumentParser):
         if subparsers.choices and cmdname in subparsers.choices:
             subparser = subparsers.choices[cmdname]
         else:
-            subparser = subparsers.add_parser(cmdname)
+            full_path = prefix + cmd_path
+            helpstr = subcommand_help.get(full_path) if subcommand_help else None
+            if helpstr:
+                subparser = subparsers.add_parser(cmdname, help=helpstr)
+            else:
+                subparser = subparsers.add_parser(cmdname)
 
-        return subparser.get_nested_subparser(*cmd_path[1:])
+        return subparser.get_nested_subparser(
+            *cmd_path[1:],
+            prefix=prefix + cmd_path[:1],
+            subcommand_help=subcommand_help,
+        )
 
 
 class CommandLineInterface(PicklableArgumentParser, Logged):
@@ -327,6 +344,8 @@ class CommandLineInterface(PicklableArgumentParser, Logged):
         output_handler: Opt[Callable] = None,
         # error handling
         exit_codes: Opt[Mapping[Type[Exception], int]] = None,
+        # documentation
+        subcommand_help: Opt[Mapping[Union[str, Tuple[str, ...]], str]] = None,
         # special features and flags
         use_multiprocessing: bool = False,
         install_bash_completion: bool = False,
@@ -434,6 +453,12 @@ class CommandLineInterface(PicklableArgumentParser, Logged):
             exception, the exit code will be equal to the highest code among those corresponding to the exception
             classes matching the raised exception (where 'match' here means that the raised exception is an instance of
             an exception class key in the exit_codes mapping but no other key is more specific).
+
+        :param subcommand_help: optional mapping from subcommand path (as space-separated string of, or tuple of,
+         command components) to help string, as would be accepted by argparse's .add_subparser(help=<help string>)
+         method. This allows for documentation of internal subcommands which serve only as parent command groups for
+         funtions or methods.
+
         :param use_multiprocessing: bool. If your app uses multiprocessing, then logging will be configured to reflect
             that fact, using appropriate process-safe loggers and handlers. This is passed through to
             `application.logging.config.configure_default_logging` via the `multiprocessing` keyword arg.
@@ -682,6 +707,19 @@ class CommandLineInterface(PicklableArgumentParser, Logged):
             )
             self._add_argument(flag, action=InstallShellCompletionAction)
 
+        if subcommand_help is not None:
+            if not isinstance(subcommand_help, Mapping):
+                raise TypeError(
+                    "subcommand_help must be a mapping from command path to help string; got {}"
+                    .format(type(subcommand_help))
+                )
+            self.subcommand_help = {
+                tuple(k.strip().split() if isinstance(k, str) else k): v
+                for k, v in subcommand_help.items()
+            }
+        else:
+            self.subcommand_help = None
+
         self.version = version
         self.package = package
 
@@ -793,21 +831,19 @@ class CommandLineInterface(PicklableArgumentParser, Logged):
                 for a in subcommand.parser._actions
                 if a.dest in ("only_commands", "omit_commands")
             ]
+            all_command_choices = filter(
+                bool,
+                self.all_subcommand_names(
+                    include_prefixes=True,
+                    filter_=lambda cmd: bool(cmd.config_subsections),
+                ),
+            )
+            all_command_choices_str = list(map(" ".join, all_command_choices))
             for arg in commands_args:
                 if arg.choices is None:
                     arg.choices = set()
-                arg.choices.update(
-                    map(
-                        " ".join,
-                        filter(
-                            bool,
-                            self.all_subcommand_names(
-                                include_prefixes=True,
-                                filter_=lambda cmd: bool(cmd.config_subsections),
-                            ),
-                        ),
-                    )
-                )
+
+                arg.choices.update(all_command_choices_str)
                 arg.metavar = "CMD-NAME"
                 choices_str = (
                     "{{{}}}".format(",".join(map(shlex.quote, sorted(arg.choices))))
@@ -865,6 +901,18 @@ class CommandLineInterface(PicklableArgumentParser, Logged):
     @property
     def cmd_name(self):
         return self.prog or os.path.split(sys.argv[0])[-1]
+
+    ##############
+    # subparsers #
+    ##############
+
+    def get_nested_subparser(
+            self, *cmd_path: str,
+            prefix: Tuple[str, ...] = (),
+            subcommand_help: Opt[Mapping[Tuple[str, ...], str]] = None):
+        if subcommand_help is None:
+            subcommand_help = self.subcommand_help
+        return super().get_nested_subparser(*cmd_path, prefix=prefix, subcommand_help=subcommand_help)
 
     def all_subcommands(
         self,

--- a/bourbaki/application/cli/signatures.py
+++ b/bourbaki/application/cli/signatures.py
@@ -99,8 +99,8 @@ class CLISignatureSpec(NamedTuple):
         namespaces = [n.nonnull_attrs for n in chain((self,), others)]
         metavars = ChainMap(*filter(None, (n.get("metavars") for n in namespaces)))
         attrs = ChainMap({"metavars": metavars}, *namespaces)
-        if attrs.get('require_options') is None:
-            attrs['require_options'] = False
+        if attrs.get("require_options") is None:
+            attrs["require_options"] = False
         return CLISignatureSpec(**attrs)
 
     def configure(

--- a/bourbaki/application/completion/compgen_python_classpaths.py
+++ b/bourbaki/application/completion/compgen_python_classpaths.py
@@ -15,7 +15,7 @@ import typing
 from typing import Union
 from warnings import warn
 
-scriptname = 'compgen_python_classpaths.py'
+scriptname = "compgen_python_classpaths.py"
 
 Module = type(sys)
 
@@ -170,9 +170,7 @@ def _debug(msg: str, **kw):
         FAIL = "\033[91m"
         ENDC = "\033[0m"
         print(
-            "\033[92m{}: {}\033[0m".format(
-                scriptname, msg.format(**kw)
-            ),
+            "\033[92m{}: {}\033[0m".format(scriptname, msg.format(**kw)),
             file=sys.stderr,
         )
 

--- a/bourbaki/application/completion/completers.py
+++ b/bourbaki/application/completion/completers.py
@@ -536,18 +536,30 @@ def _ensure_lines(lines, textfile: str):
 
 
 def _install_shell_completion_helpers(completions_helpers_file):
-    source = pkgutil.get_data('bourbaki.application.completion', BASH_COMPLETION_HELPERS_FILENAME).strip()
+    source = pkgutil.get_data(
+        "bourbaki.application.completion", BASH_COMPLETION_HELPERS_FILENAME
+    ).strip()
     completions_helpers_file_absolute = os.path.expanduser(completions_helpers_file)
 
     if not os.path.exists(completions_helpers_file_absolute):
         with open(completions_helpers_file_absolute, "wb") as outfile:
-            print("INSTALLING BASH COMPLETION HELPERS AT {}".format(completions_helpers_file_absolute), file=sys.stderr)
+            print(
+                "INSTALLING BASH COMPLETION HELPERS AT {}".format(
+                    completions_helpers_file_absolute
+                ),
+                file=sys.stderr,
+            )
             outfile.write(source)
     else:
         with open(completions_helpers_file_absolute, "rb+") as outfile:
             old_source = outfile.read().strip()
             if source != old_source:
-                print("REINSTALLING BASH COMPLETION HELPERS AT {}".format(completions_helpers_file_absolute), file=sys.stderr)
+                print(
+                    "REINSTALLING BASH COMPLETION HELPERS AT {}".format(
+                        completions_helpers_file_absolute
+                    ),
+                    file=sys.stderr,
+                )
                 outfile.seek(0)
                 outfile.truncate()
                 outfile.write(source)

--- a/bourbaki/application/config/io.py
+++ b/bourbaki/application/config/io.py
@@ -26,7 +26,9 @@ LEGAL_CONFIG_EXTENSIONS = {".yml", ".yaml", ".json", ".toml", ".py", ".ini"}
 EMPTY_CONFIG_VALUE = "________"
 # Force indentation for small collections for readability, don't sort keys to preserve method def order in CLIs
 JSON_DUMP_KWARGS = dict(indent=2, sort_keys=False)
-YAML_DUMP_KWARGS = dict(default_flow_style=False, width=MAX_PY_WIDTH, sort_keys=False, indent=2)
+YAML_DUMP_KWARGS = dict(
+    default_flow_style=False, width=MAX_PY_WIDTH, sort_keys=False, indent=2
+)
 
 loaders = {
     ".yml": yaml.safe_load,

--- a/bourbaki/application/typed_io/config_repr_.py
+++ b/bourbaki/application/typed_io/config_repr_.py
@@ -53,7 +53,7 @@ from .parsers import EnumParser
 NoneType = type(None)
 
 null_config_repr = None
-null_config_repr_str = 'null'
+null_config_repr_str = "null"
 
 bytes_config_repr = [byte_repr, ellipsis_]
 bool_config_repr = type_spec(bool)

--- a/bourbaki/application/typed_io/main.py
+++ b/bourbaki/application/typed_io/main.py
@@ -4,7 +4,12 @@ import enum
 from inspect import Parameter
 from argparse import ArgumentParser, OPTIONAL, ONE_OR_MORE, ZERO_OR_MORE
 from functools import lru_cache
-from bourbaki.introspection.types import get_generic_args, deconstruct_generic, is_named_tuple_class, issubclass_generic
+from bourbaki.introspection.types import (
+    get_generic_args,
+    deconstruct_generic,
+    is_named_tuple_class,
+    issubclass_generic,
+)
 from bourbaki.introspection.types.abcs import NonStrCollection
 from .cli_parse import cli_parser, cli_option_parser
 from .cli_nargs_ import cli_nargs, cli_option_nargs, cli_action
@@ -43,7 +48,7 @@ class ArgSource(enum.Enum):
 
 CLI, CONFIG, ENV = ArgSource.CLI, ArgSource.CONFIG, ArgSource.ENV
 
-__all__ = ['ArgSource', 'TypedIO']
+__all__ = ["ArgSource", "TypedIO"]
 
 
 class TypedIO(PicklableWithType):
@@ -226,7 +231,9 @@ class TypedIO(PicklableWithType):
             )
         else:
             if derive_cli_completer or derive_cli_repr or derive_cli_nargs:
-                raise ValueError("Can't derive cli completer/repr/nargs when no cli_parser_ is passed")
+                raise ValueError(
+                    "Can't derive cli completer/repr/nargs when no cli_parser_ is passed"
+                )
         for dispatcher, func in [
             (cli_nargs, cli_nargs_),
             (cli_repr, cli_repr_),
@@ -284,7 +291,9 @@ class TypedIO(PicklableWithType):
     def cli_completer(self):
         return cli_completer(self.type_)
 
-    def cli_completer_fallback(self, param_name: str, nargs: Union[int, str], positional: bool) -> Complete:
+    def cli_completer_fallback(
+        self, param_name: str, nargs: Union[int, str], positional: bool
+    ) -> Complete:
         """complete positional args by name, options with a type repr"""
         if positional:
             if isinstance(nargs, int):
@@ -293,7 +302,7 @@ class TypedIO(PicklableWithType):
                     pos_names = map(str.upper, self.type_._fields)
                 else:
                     metavar = param_name.upper()
-                    pos_names = [metavar + '_%d' % i for i in range(1, nargs + 1)]
+                    pos_names = [metavar + "_%d" % i for i in range(1, nargs + 1)]
                 completer = CompleteTuple(*map(CompleteChoices, pos_names))
             else:
                 completer = CompleteChoices(param_name.upper())
@@ -507,7 +516,9 @@ class TypedIO(PicklableWithType):
             completer = None
 
         if isinstance(completer, (type(None), type(NoComplete))):
-            completer = self.cli_completer_fallback(param.name, nargs=kw.get('nargs'), positional=positional)
+            completer = self.cli_completer_fallback(
+                param.name, nargs=kw.get("nargs"), positional=positional
+            )
 
         action.completer = completer
         action.positional = positional

--- a/tests/cli.py
+++ b/tests/cli.py
@@ -82,6 +82,13 @@ cli = CommandLineInterface(
     arg_lookup_order=(CLI, CONFIG, ENV),
     package_info_keys=("version", "license", "summary", "platforms"),
     suppress_setup_warnings=True,
+    subcommand_help={
+        "print": "print things",
+        "print tuple": "print all kinds of tuples",
+        "leading": "test commands with leading variadic args",
+        "get": "get attributes",
+        "cant": "test things that can't be parsed from the command line, only config",
+    }
 )
 
 
@@ -137,7 +144,7 @@ class MyCommandLineApp(Generic[Num], Logged):
     @cli_spec.command_prefix("print", "tuple")
     def tuple_kwarg(self, *, tup: Tuple[int, Num, float]):
         """
-        print a tuple
+        print a tuple passed as an option
 
         print all the entries in a tuple that was passed
         :param tup: a tuple of three things
@@ -159,7 +166,7 @@ class MyCommandLineApp(Generic[Num], Logged):
     @cli_spec.command_prefix("print", "tuple")
     def tuple_pos(self, tup: Tuple[int, Num, float]):
         """
-        print a tuple
+        print a tuple passed as a positional arg
 
         print all the entries in a tuple that was passed
         :param tup: a tuple of three things


### PR DESCRIPTION
added subommand help as a constructor arg to CommandLineInterface to allow documenting internal commands that serve only as prefixes to other commands