### PR TITLE
Add Python 3.14 compatibility, require >=3.10

### DIFF
--- a/bourbaki/__init__.py
+++ b/bourbaki/__init__.py
@@ -1,1 +1,0 @@
-__import__("pkg_resources").declare_namespace(__name__)

--- a/bourbaki/application/cli/actions.py
+++ b/bourbaki/application/cli/actions.py
@@ -9,11 +9,10 @@ from ..completion import install_shell_completion
 
 
 def load_package_info(package):
-    from pkg_resources import get_distribution
+    from importlib.metadata import distribution
     from pkginfo import Distribution
 
-    dist = get_distribution(package)
-    meta = dist.get_metadata(dist.PKG_INFO)
+    meta = str(distribution(package).metadata)
     d = Distribution()
     d.parse(meta)
     return d.__dict__

--- a/bourbaki/application/config/python.py
+++ b/bourbaki/application/config/python.py
@@ -53,8 +53,7 @@ def is_json_serializable(conf):
 
 # safe python syntactic constructs for configuration
 legal_python_config_exprs = (
-    ast.Num,
-    ast.Str,
+    ast.Constant,
     ast.BinOp,
     ast.operator,
     ast.Compare,
@@ -64,15 +63,12 @@ legal_python_config_exprs = (
     ast.Tuple,
     ast.Dict,
     ast.Set,
-    ast.Bytes,
     ast.Subscript,
-    ast.Ellipsis,
     ast.ListComp,
     ast.DictComp,
     ast.SetComp,
     ast.comprehension,
     ast.keyword,
-    ast.NameConstant,
     ast.Assign,
     ast.Call,
 )

--- a/bourbaki/application/typed_io/config_decode.py
+++ b/bourbaki/application/typed_io/config_decode.py
@@ -115,7 +115,7 @@ def str_to_bytes(s, type_=bytes, exc_type=ConfigTypedInputError):
         raise exc_type(type_, s, e)
     else:
         expr = t.body
-        if not isinstance(expr, ast.Bytes):
+        if not (isinstance(expr, ast.Constant) and isinstance(expr.value, bytes)):
             raise exc_type(
                 type_,
                 s,

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,13 +17,16 @@ python_files = tests/test*.py
 [metadata]
 name = bourbaki.application
 version = file: version.txt
-namespace_packages = bourbaki
 author = Matthew Hawthorn
 author_email = hawthorn.matthew@gmail.com
-classifiers = 
+python_requires = >=3.10
+classifiers =
 	Programming Language :: Python :: 3
-	Programming Language :: Python :: 3.6
-	Programming Language :: Python :: 3.7
+	Programming Language :: Python :: 3.10
+	Programming Language :: Python :: 3.11
+	Programming Language :: Python :: 3.12
+	Programming Language :: Python :: 3.13
+	Programming Language :: Python :: 3.14
 	License :: OSI Approved :: Apache Software License
 	Operating System :: POSIX :: Linux
 	Operating System :: MacOS :: MacOS X


### PR DESCRIPTION
Python 3.14 removed several deprecated features that `bourbaki-application` relies on. This PR fixes all of them with minimal, targeted changes.

## Changes

**`pkg_resources` removal (`setuptools` 82)**
- Deleted `bourbaki/__init__.py` (which called `pkg_resources.declare_namespace()`). PEP 420 implicit namespace packages don't need this file.
- Replaced `pkg_resources.get_distribution()` with `importlib.metadata.distribution()` in `cli/actions.py`
- Removed `namespace_packages = bourbaki` from `setup.cfg`

**`ast` node removals (Python 3.14)**
- Replaced `ast.Num`, `ast.Str`, `ast.Bytes`, `ast.Ellipsis`, `ast.NameConstant` with `ast.Constant` in the `legal_python_config_exprs` tuple (`config/python.py`). All five were deprecated since 3.8 and removed in 3.14.
- Fixed `isinstance(expr, ast.Bytes)` to `isinstance(expr, ast.Constant) and isinstance(expr.value, bytes)` in `typed_io/config_decode.py`

**Version metadata**
- Added `python_requires = >=3.10`
- Updated classifiers to 3.10–3.14